### PR TITLE
Added command to mint + distribute NFTs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "commander": "^12.1.0",
         "es-toolkit": "^1.16.0",
         "inquirer": "^10.1.8",
-        "ts-handling": "^0.2.0"
+        "ts-handling": "^0.2.2"
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
@@ -6230,9 +6230,9 @@
       }
     },
     "node_modules/ts-handling": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ts-handling/-/ts-handling-0.2.0.tgz",
-      "integrity": "sha512-mg8BJJtkXHyIj4cHU+m9HYeU2PfXB3Odc4CaX0Oze0I+Z5zk07zWKENIzG6+KeYwS085yMskSBj/LZ+DNonQ9w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ts-handling/-/ts-handling-0.2.2.tgz",
+      "integrity": "sha512-3i1jI0R6dZU+9xkNteO/CVMMl01m3Mdk1ygGdMZL2oI+91qooZYo9h5mSKZ6byhhjZV4qV6kyi3Ij1fJtynqEQ==",
       "dependencies": {
         "flatted": "^3.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "commander": "^12.1.0",
     "es-toolkit": "^1.16.0",
     "inquirer": "^10.1.8",
-    "ts-handling": "^0.2.0"
+    "ts-handling": "^0.2.2"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "concurrently \"aiken build\" \"npx tsc\"",
     "mint": "npx tsx src/mint.ts",
     "nft": "npx tsx src/nft.ts",
+    "distribute": "npx tsx src/distribute.ts",
     "burn": "npx tsx src/burn.ts",
     "prettier": "npx prettier -w '**/*.{js,jsx,ts,tsx,json,yml.j2,yml,yaml,.*}'",
     "lint": "concurrently \"npx prettier --check '**/*.{js,jsx,ts,tsx,json,yml.j2,yml,yaml,.*}'\" \"npx eslint . --max-warnings=0\""

--- a/src/distribute.ts
+++ b/src/distribute.ts
@@ -93,9 +93,10 @@ const program = new Command()
       const tx = lucid.newTx().readFrom([refScript]);
 
       for (const [j, token] of tokens.entries())
-        tx
-          .mintAssets({ [token]: 1n }, Data.void())
-          .pay.ToAddress(addresses[j], { [token]: 1n });
+        tx.mintAssets({ [token]: 1n }, Data.void()).pay.ToAddress(
+          addresses[j],
+          { [token]: 1n }
+        );
 
       const [, , mintTx] = await tx.chain();
       txs.push(mintTx);

--- a/src/distribute.ts
+++ b/src/distribute.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from "fs";
+import { password } from "@inquirer/prompts";
+import {
+  applyParamsToScript,
+  Data,
+  getAddressDetails,
+  MintingPolicy,
+  mintingPolicyToId,
+  Network,
+  TxSignBuilder,
+  UTxO,
+  validatorToAddress,
+} from "@lucid-evolution/lucid";
+import { type } from "arktype";
+import { Seed } from "cardano-ts";
+import { Command } from "commander";
+import { chunk } from "es-toolkit/array";
+import { isProblem, mayFail, Problem } from "ts-handling";
+import { loadLucid } from "wallet";
+import { Config, logThenExit, validate } from "./inputs";
+import { loadPlutus } from "./script";
+import { getNetwork, loadWalletFromSeed } from "./wallet";
+
+const amountPerTx = 220;
+
+const program = new Command()
+  .name("distribute")
+  .description(
+    "Mints and distributes NFTs to a list of addresses. Each NFT will have a unique name."
+  )
+  .argument(
+    "<filename>",
+    "The filename containing the list of addresses to send tokens to"
+  )
+  .action(async ($filename) => {
+    const config = validate(Config, process.env);
+    const projectId = config.BLOCKFROST_API_KEY;
+    const lucid = await loadLucid(projectId);
+    const addresses = validate(Addresses(lucid.config().network), $filename);
+    const amount = addresses.length;
+
+    const seed = await password({ message: "Enter your seed phrase" });
+    if (!seed) return logThenExit("No seed phrase provided");
+
+    const wallet = await loadWalletFromSeed(projectId, seed);
+    if (!wallet.utxos.length) return logThenExit("Wallet must be funded");
+
+    const plutus = (await loadPlutus("multiple.mint")).unwrap();
+    if (plutus instanceof Problem) return logThenExit(plutus.error);
+
+    const network = getNetwork(projectId);
+    const txs: TxSignBuilder[] = [];
+    lucid.selectWallet.fromAddress(wallet.address, wallet.utxos);
+    const key = new Seed(
+      seed,
+      lucid.config().network === "Mainnet" ? "mainnet" : "testnet"
+    ).getPrivateKey();
+
+    const chunks = chunk(Array.from({ length: Number(amount) }), amountPerTx);
+    const setup = lucid
+      .newTx()
+      .pay.ToAddress(wallet.address, { lovelace: 200000000n });
+    chunks.forEach(() =>
+      setup.pay.ToAddress(wallet.address, { lovelace: 200000000n })
+    );
+    const [[setupUtxo, ...refs], , setupTx] = await setup.chain();
+    lucid.selectWallet.fromAddress(wallet.address, [setupUtxo]);
+    txs.push(setupTx);
+
+    const blackhole = createBlackholeAddress(network);
+    const script = createScript(plutus, refs[0]);
+    const policy = mintingPolicyToId(script);
+    const tokenChunks = chunk(generateTokens(policy, amount), amountPerTx);
+
+    const deploy = lucid
+      .newTx()
+      .pay.ToContract(
+        blackhole,
+        { kind: "inline", value: Data.void() },
+        undefined,
+        script
+      );
+    const [, [refScript], deployTx] = await deploy.chain();
+    if (!refScript.scriptRef) return logThenExit("Script didn't deploy");
+    txs.push(deployTx);
+
+    for (let i = 0; i < tokenChunks.length; i++) {
+      const tokens = tokenChunks[i];
+      const ref = refs[i];
+      lucid.selectWallet.fromAddress(wallet.address, [ref]);
+      const tx = lucid.newTx().readFrom([refScript]);
+
+      for (const token of tokens) tx.mintAssets({ [token]: 1n }, Data.void());
+
+      const [, , mintTx] = await tx.chain();
+      txs.push(mintTx);
+    }
+
+    for (const tx of txs) {
+      const completed = await tx.sign.withPrivateKey(key).complete();
+      const submitted = await completed.submit();
+      console.log(`Submitted ${submitted}`);
+    }
+  });
+
+const Addresses = (network: Network) =>
+  type("string").pipe((v, ctx) => {
+    const networkId = network === "Mainnet" ? 1 : 0;
+    const data = mayFail(() => readFileSync(v, "utf8")).unwrap();
+    if (isProblem(data)) return ctx.error("valid filename");
+
+    const addresses = data.split(/\r?\n/).filter((line) => line.trim() !== "");
+
+    for (const address of addresses) {
+      const details = mayFail(() => getAddressDetails(address)).unwrap();
+      const error = (() => {
+        if (isProblem(details)) return "valid address";
+        if (details.networkId !== networkId) return "correct network";
+        if (!details.paymentCredential)
+          return "valid address with payment credential";
+        if (!details.stakeCredential)
+          return "valid address with stake credential";
+      })();
+
+      if (error) return ctx.error(`${error}; error with ${address}`);
+    }
+
+    if (!addresses.length) return ctx.error("a list of addresses");
+
+    return addresses;
+  });
+
+const createScript = (plutus: string, ref: UTxO): MintingPolicy => {
+  return {
+    type: "PlutusV2",
+    script: applyParamsToScript(plutus, [ref.txHash]),
+  };
+};
+
+const createBlackholeAddress = (network: Network) => {
+  const header = "5839010000322253330033371e9101203";
+  const body = Array.from({ length: 63 }, () =>
+    Math.floor(Math.random() * 10)
+  ).join("");
+  const footer = "0048810014984d9595cd01";
+
+  return validatorToAddress(network, {
+    type: "PlutusV2",
+    script: `${header}${body}${footer}`,
+  });
+};
+
+const generateTokens = (policy: string, amount: number) =>
+  Array.from({ length: amount }).map(
+    () =>
+      policy +
+      [...Array(64)]
+        .map(() => Math.floor(Math.random() * 16).toString(16))
+        .join("")
+  );
+
+program.parseAsync(process.argv);

--- a/src/distribute.ts
+++ b/src/distribute.ts
@@ -21,7 +21,7 @@ import { Config, logThenExit, validate } from "./inputs";
 import { loadPlutus } from "./script";
 import { getNetwork, loadWalletFromSeed } from "./wallet";
 
-const amountPerTx = 220;
+const amountPerTx = 90;
 
 const program = new Command()
   .name("distribute")

--- a/src/distribute.ts
+++ b/src/distribute.ts
@@ -110,6 +110,7 @@ const Addresses = (network: Network) =>
     if (isProblem(data)) return ctx.error("valid filename");
 
     const addresses = data.split(/\r?\n/).filter((line) => line.trim() !== "");
+    const stakeKeys: Record<string, string> = {};
 
     for (const address of addresses) {
       const details = mayFail(() => getAddressDetails(address)).unwrap();
@@ -120,6 +121,12 @@ const Addresses = (network: Network) =>
           return "valid address with payment credential";
         if (!details.stakeCredential)
           return "valid address with stake credential";
+
+        const key = details.stakeCredential.hash;
+        if (key in stakeKeys)
+          console.error("duplicate:", address, stakeKeys[key]);
+
+        stakeKeys[key] = address;
       })();
 
       if (error) return ctx.error(`${error}; error with ${address}`);


### PR DESCRIPTION
In this PR I propose introducing a command to both mint and distribute NFTs. The `npm run distribute <filename>` command accepts a filename as input, which should be a list of addresses. It then will simultaneously mint and send a NFT to each address. The name of each NFT is randomly generated and unique.